### PR TITLE
Support arm64 for more tests/examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ build-example-$(1)-$(2):
 	docker buildx build --load ${DOCKER_BUILD_ARGS} ${DOCKER_CACHE_ARGS} \
 		--file ./examples/$1/$2/Dockerfile \
 		--tag ${IMAGE_NAME} \
-		--platform linux/${ARCH} .
+		.
 	if [ "${LOAD_TO_KIND}" = "true" ]; then \
 		kind load docker-image ${IMAGE_NAME};\
 	fi

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 export STAGINGVERSION ?= $(shell git describe --long --tags --match='v*' --dirty 2>/dev/null || git rev-list -n1 HEAD)
-export BUILD_DATE ?= $(shell date --iso-8601=minutes)
+export BUILD_DATE ?= $(shell date +"%Y-%m-%dT%H:%M:%S%z")
 BINDIR ?= bin
 LDFLAGS ?= -s -w -X main.version=${STAGINGVERSION} -X main.builddate=${BUILD_DATE} -extldflags '-static'
 
@@ -33,7 +33,6 @@ ifneq ("$(shell docker buildx build --help | grep 'provenance')", "")
 DOCKER_BUILD_ARGS += --provenance=false
 endif
 
-ARCH = $(shell dpkg --print-architecture)
 BUILDX_BUILDER = mfcp-builder
 
 LOAD_TO_KIND ?= false
@@ -49,22 +48,22 @@ all: build-driver build-examples
 
 driver:
 	mkdir -p ${BINDIR}
-	CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "${LDFLAGS}" -o ${BINDIR}/${DRIVER_BINARY} cmd/csi_driver/main.go
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "${LDFLAGS}" -o ${BINDIR}/${DRIVER_BINARY} cmd/csi_driver/main.go
 
 fuse-starter:
 	mkdir -p ${BINDIR}
-	CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "${LDFLAGS}" -o ${BINDIR}/${STARTER_BINARY} cmd/fuse_starter/main.go
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "${LDFLAGS}" -o ${BINDIR}/${STARTER_BINARY} cmd/fuse_starter/main.go
 
 fusermount3-proxy:
 	mkdir -p ${BINDIR}
-	CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "${LDFLAGS}" -o ${BINDIR}/${FUSERMOUNT3PROXY_BINARY} cmd/fusermount3-proxy/main.go
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "${LDFLAGS}" -o ${BINDIR}/${FUSERMOUNT3PROXY_BINARY} cmd/fusermount3-proxy/main.go
 
 build-driver:
 	$(eval IMAGE_NAME := ${DRIVER_IMAGE}:${STAGINGVERSION})
 	docker buildx build --load ${DOCKER_BUILD_ARGS} ${DOCKER_CACHE_ARGS} \
 		--file ./cmd/csi_driver/Dockerfile \
 		--tag ${IMAGE_NAME} \
-		--platform linux/${ARCH} .
+		.
 	if [ "${LOAD_TO_KIND}" = "true" ]; then \
 		kind load docker-image ${IMAGE_NAME};\
 	fi
@@ -113,10 +112,6 @@ push-example-$(1)-$(2):
 		--platform linux/amd64,linux/arm64 .
 endef
 
-ifeq ("$(ARCH)", "arm64")
-$(eval $(call example-template,proxy,sshfs))
-$(eval $(call example-template,starter,sshfs))
-else
 $(eval $(call example-template,proxy,mountpoint-s3))
 $(eval $(call example-template,proxy,goofys))
 $(eval $(call example-template,proxy,s3fs))
@@ -125,7 +120,7 @@ $(eval $(call example-template,proxy,gcsfuse))
 $(eval $(call example-template,proxy,sshfs))
 $(eval $(call example-template,starter,ros3fs))
 $(eval $(call example-template,starter,sshfs))
-endif
+
 
 .PHONY: build-examples
 build-examples: $(BUILD_EXAMPLES)
@@ -145,10 +140,6 @@ test-example-$(1)-$(2):
 	./examples/check.sh ./$1/$2 mfcp-example-$1-$2 $3 $4 $5 $6
 endef
 
-ifeq ("$(ARCH)", "arm64")
-$(eval $(call test-example-template,proxy,sshfs,starter,/root/sshfs-example/test.txt,busybox,/data/test.txt))
-$(eval $(call test-example-template,starter,sshfs,starter,/root/sshfs-example/test.txt,busybox,/data/test.txt))
-else
 $(eval $(call test-example-template,proxy,mountpoint-s3,starter,/test.txt,busybox,/data/test.txt))
 $(eval $(call test-example-template,proxy,goofys,starter,/test.txt,busybox,/data/test.txt))
 $(eval $(call test-example-template,proxy,s3fs,starter,/test.txt,busybox,/data/test.txt))
@@ -156,7 +147,6 @@ $(eval $(call test-example-template,proxy,ros3fs,starter,/test.txt,busybox,/data
 $(eval $(call test-example-template,proxy,sshfs,starter,/root/sshfs-example/test.txt,busybox,/data/test.txt))
 $(eval $(call test-example-template,starter,ros3fs,starter,/test.txt,busybox,/data/test.txt))
 $(eval $(call test-example-template,starter,sshfs,starter,/root/sshfs-example/test.txt,busybox,/data/test.txt))
-endif
 
 .PHONY: test-examples
 test-examples: $(EXAMPLE_TESTS)

--- a/examples/proxy/gcsfuse/Dockerfile
+++ b/examples/proxy/gcsfuse/Dockerfile
@@ -5,12 +5,13 @@ ADD . .
 RUN make fusermount3-proxy BINDIR=/bin
 
 FROM ubuntu:22.04
+ARG TARGETARCH
 
 RUN apt update && apt upgrade -y
 RUN apt install -y ca-certificates wget libfuse2 fuse3
 
 # prepare for MinIO
-RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
+RUN wget https://dl.min.io/client/mc/release/linux-${TARGETARCH}/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
 
 COPY <<EOF /test.txt
 This is a test file for minio
@@ -25,7 +26,7 @@ set -eux
 EOF
 RUN chmod +x /configure_minio.sh
 
-RUN wget https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v1.1.0/gcsfuse_1.1.0_amd64.deb -O gcsfuse.deb && dpkg -i gcsfuse.deb
+RUN wget https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v2.4.0/gcsfuse_2.4.0_${TARGETARCH}.deb -O gcsfuse.deb && dpkg -i gcsfuse.deb
 
 COPY --from=fusermount3-proxy-builder /bin/fusermount3-proxy /bin/fusermount3
 RUN ln -sf /bin/fusermount3 /bin/fusermount

--- a/examples/proxy/goofys/Dockerfile
+++ b/examples/proxy/goofys/Dockerfile
@@ -5,12 +5,13 @@ ADD . .
 RUN make fusermount3-proxy BINDIR=/bin
 
 FROM ubuntu:22.04
+ARG TARGETARCH
 
 RUN apt update && apt upgrade -y
 RUN apt install -y ca-certificates wget libfuse2 fuse3
 
 # prepare for MinIO
-RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
+RUN wget https://dl.min.io/client/mc/release/linux-${TARGETARCH}/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
 
 COPY <<EOF /test.txt
 This is a test file for minio

--- a/examples/proxy/mountpoint-s3/Dockerfile
+++ b/examples/proxy/mountpoint-s3/Dockerfile
@@ -5,12 +5,13 @@ ADD . .
 RUN make fusermount3-proxy BINDIR=/bin
 
 FROM ubuntu:22.04
+ARG TARGETARCH
 
 RUN apt update && apt upgrade -y
 RUN apt install -y ca-certificates wget libfuse2 fuse3
 
 # prepare for MinIO
-RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
+RUN wget https://dl.min.io/client/mc/release/linux-${TARGETARCH}/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
 
 COPY <<EOF /test.txt
 This is a test file for minio
@@ -25,7 +26,7 @@ set -eux
 EOF
 RUN chmod +x /configure_minio.sh
 
-RUN wget https://s3.amazonaws.com/mountpoint-s3-release/1.0.1/x86_64/mount-s3-1.0.1-x86_64.deb -O mount-s3.deb && dpkg -i mount-s3.deb
+RUN wget https://s3.amazonaws.com/mountpoint-s3-release/latest/${TARGETARCH}/mount-s3.deb -O mount-s3.deb && dpkg -i mount-s3.deb
 
 COPY --from=fusermount3-proxy-builder /bin/fusermount3-proxy /bin/fusermount3
 RUN ln -sf /bin/fusermount3 /bin/fusermount

--- a/examples/proxy/mountpoint-s3/Dockerfile
+++ b/examples/proxy/mountpoint-s3/Dockerfile
@@ -26,7 +26,7 @@ set -eux
 EOF
 RUN chmod +x /configure_minio.sh
 
-RUN wget https://s3.amazonaws.com/mountpoint-s3-release/latest/${TARGETARCH}/mount-s3.deb -O mount-s3.deb && dpkg -i mount-s3.deb
+RUN if [ "$TARGETARCH" = "amd64" ]; then TARGETARCH=x86_64; fi && wget https://s3.amazonaws.com/mountpoint-s3-release/latest/${TARGETARCH}/mount-s3.deb -O mount-s3.deb && dpkg -i mount-s3.deb
 
 COPY --from=fusermount3-proxy-builder /bin/fusermount3-proxy /bin/fusermount3
 RUN ln -sf /bin/fusermount3 /bin/fusermount

--- a/examples/proxy/ros3fs/Dockerfile
+++ b/examples/proxy/ros3fs/Dockerfile
@@ -16,12 +16,13 @@ ADD . .
 RUN make fusermount3-proxy BINDIR=/bin
 
 FROM ubuntu:22.04
+ARG TARGETARCH
 
 RUN apt update && apt upgrade -y
 RUN apt install -y ca-certificates wget libfuse2 fuse3
 
 # prepare for MinIO
-RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
+RUN wget https://dl.min.io/client/mc/release/linux-${TARGETARCH}/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
 
 COPY <<EOF /test.txt
 This is a test file for minio

--- a/examples/proxy/s3fs/Dockerfile
+++ b/examples/proxy/s3fs/Dockerfile
@@ -6,11 +6,12 @@ RUN make fusermount3-proxy BINDIR=/bin
 
 FROM ubuntu:22.04
 
+ARG TARGETARCH
 RUN apt update && apt upgrade -y
 RUN apt install -y ca-certificates wget libfuse2 fuse3
 
 # prepare for MinIO
-RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
+RUN wget https://dl.min.io/client/mc/release/linux-${TARGETARCH}/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
 
 COPY <<EOF /test.txt
 This is a test file for minio

--- a/examples/proxy/sshfs/Dockerfile
+++ b/examples/proxy/sshfs/Dockerfile
@@ -5,6 +5,7 @@ ADD . .
 RUN make fusermount3-proxy BINDIR=/bin
 
 FROM ubuntu:22.04
+ARG TARGETARCH
 
 RUN apt update && apt upgrade -y
 RUN apt install -y ca-certificates wget libfuse2 fuse3

--- a/examples/starter/ros3fs/Dockerfile
+++ b/examples/starter/ros3fs/Dockerfile
@@ -16,12 +16,13 @@ ADD . .
 RUN make fuse-starter BINDIR=/bin
 
 FROM ubuntu:22.04
+ARG TARGETARCH
 
 RUN apt update && apt upgrade -y
 RUN apt install -y ca-certificates wget libfuse2 fuse3
 
 # prepare for MinIO
-RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
+RUN wget https://dl.min.io/client/mc/release/linux-${TARGETARCH}/mc -O /usr/bin/mc && chmod +x /usr/bin/mc
 
 COPY <<EOF /test.txt
 This is a test file for minio

--- a/examples/starter/sshfs/Dockerfile
+++ b/examples/starter/sshfs/Dockerfile
@@ -5,6 +5,7 @@ ADD . .
 RUN make fuse-starter BINDIR=/bin
 
 FROM ubuntu:22.04
+ARG TARGETARCH
 
 RUN apt update && apt upgrade -y
 RUN apt install -y ca-certificates wget libfuse2 fuse3


### PR DESCRIPTION
Currently, for arm64, it only tests sshfs in proxy&starter mode.
This PR extends arm64 support for other examples.

parahaps relates to #5 
 
<details>
<summary>manual e2e test result on darwin/arm64</summary>

```console
❯ uname -ms
Darwin arm64
❯ kind version
kind v0.23.0 go1.21.10 darwin/arm64

❯ make test-e2e
...
./examples/check.sh ./proxy/mountpoint-s3 mfcp-example-proxy-mountpoint-s3 starter /test.txt busybox /data/test.txt
Checking Pod "mfcp-example-proxy-mountpoint-s3"...
pod/mfcp-example-proxy-mountpoint-s3 created
waiting for pod
waiting for pod
waiting for pod
waiting for pod
waiting for pod
waiting for pod
waiting for pod
waiting for pod
waiting for pod
waiting for pod
waiting for pod
waiting for pod
Pod is ready.
FUSE is mounted.
OK.
pod "mfcp-example-proxy-mountpoint-s3" deleted
./examples/check.sh ./proxy/goofys mfcp-example-proxy-goofys starter /test.txt busybox /data/test.txt
Checking Pod "mfcp-example-proxy-goofys"...
pod/mfcp-example-proxy-goofys created
waiting for pod
waiting for pod
waiting for pod
waiting for pod
Pod is ready.
FUSE is mounted.
OK.
pod "mfcp-example-proxy-goofys" deleted
./examples/check.sh ./proxy/s3fs mfcp-example-proxy-s3fs starter /test.txt busybox /data/test.txt
Checking Pod "mfcp-example-proxy-s3fs"...
pod/mfcp-example-proxy-s3fs created
waiting for pod
waiting for pod
waiting for pod
waiting for pod
Pod is ready.
FUSE is mounted.
OK.
pod "mfcp-example-proxy-s3fs" deleted
./examples/check.sh ./proxy/ros3fs mfcp-example-proxy-ros3fs starter /test.txt busybox /data/test.txt
Checking Pod "mfcp-example-proxy-ros3fs"...
pod/mfcp-example-proxy-ros3fs created
waiting for pod
waiting for pod
waiting for pod
waiting for pod
Pod is ready.
waiting for mount
FUSE is mounted.
OK.
pod "mfcp-example-proxy-ros3fs" deleted
./examples/check.sh ./proxy/sshfs mfcp-example-proxy-sshfs starter /root/sshfs-example/test.txt busybox /data/test.txt
Checking Pod "mfcp-example-proxy-sshfs"...
pod/mfcp-example-proxy-sshfs created
waiting for pod
waiting for pod
Pod is ready.
FUSE is mounted.
OK.
pod "mfcp-example-proxy-sshfs" deleted
./examples/check.sh ./starter/ros3fs mfcp-example-starter-ros3fs starter /test.txt busybox /data/test.txt
Checking Pod "mfcp-example-starter-ros3fs"...
pod/mfcp-example-starter-ros3fs created
waiting for pod
waiting for pod
waiting for pod
waiting for pod
waiting for pod
Pod is ready.
FUSE is mounted.
OK.
pod "mfcp-example-starter-ros3fs" deleted
./examples/check.sh ./starter/sshfs mfcp-example-starter-sshfs starter /root/sshfs-example/test.txt busybox /data/test.txt
Checking Pod "mfcp-example-starter-sshfs"...
pod/mfcp-example-starter-sshfs created
waiting for pod
waiting for pod
Pod is ready.
FUSE is mounted.
OK.
pod "mfcp-example-starter-sshfs" deleted
```
</details>
